### PR TITLE
feat: enable `fwmark` (`SO_MARK`) for outgoing sockets (#202)

### DIFF
--- a/cmd/outline-ss-server/config.go
+++ b/cmd/outline-ss-server/config.go
@@ -24,16 +24,22 @@ import (
 type ServiceConfig struct {
 	Listeners []ListenerConfig
 	Keys      []KeyConfig
+	Dialer    DialerConfig
 }
 
 type ListenerType string
 
 const listenerTypeTCP ListenerType = "tcp"
+
 const listenerTypeUDP ListenerType = "udp"
 
 type ListenerConfig struct {
 	Type    ListenerType
 	Address string
+}
+
+type DialerConfig struct {
+	Fwmark uint
 }
 
 type KeyConfig struct {

--- a/cmd/outline-ss-server/config_example.yml
+++ b/cmd/outline-ss-server/config_example.yml
@@ -21,19 +21,22 @@ services:
       - type: udp
         address: "[::]:9000"
     keys:
-        - id: user-0
-          cipher: chacha20-ietf-poly1305
-          secret: Secret0
-        - id: user-1
-          cipher: chacha20-ietf-poly1305
-          secret: Secret1
-
+      - id: user-0
+        cipher: chacha20-ietf-poly1305
+        secret: Secret0
+      - id: user-1
+        cipher: chacha20-ietf-poly1305
+        secret: Secret1
+    dialer:
+      # fwmark can be used in conjunction with other Linux networking features like cgroups, network namespaces, and TC (Traffic Control) for sophisticated network management.
+      # Value of 0 disables fwmark (SO_MARK) (Linux Only)
+      fwmark: 0
   - listeners:
       - type: tcp
         address: "[::]:9001"
       - type: udp
         address: "[::]:9001"
     keys:
-        - id: user-2
-          cipher: chacha20-ietf-poly1305
-          secret: Secret2
+      - id: user-2
+        cipher: chacha20-ietf-poly1305
+        secret: Secret2

--- a/service/socketopts_linux.go
+++ b/service/socketopts_linux.go
@@ -1,0 +1,33 @@
+// Copyright 2024 Jigsaw Operations LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package service
+
+import (
+	"os"
+	"syscall"
+)
+
+func SetFwmark(rc syscall.RawConn, fwmark uint) error {
+	var err error
+	rc.Control(func(fd uintptr) {
+		err = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_MARK, int(fwmark))
+	})
+	if err != nil {
+		return os.NewSyscallError("failed to set fwmark for socket", err)
+	}
+	return nil
+}

--- a/service/tcp_linux.go
+++ b/service/tcp_linux.go
@@ -1,0 +1,40 @@
+// Copyright 2024 Jigsaw Operations LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package service
+
+import (
+	"net"
+	"syscall"
+
+	"github.com/Jigsaw-Code/outline-sdk/transport"
+
+	onet "github.com/Jigsaw-Code/outline-ss-server/net"
+)
+
+// fwmark can be used in conjunction with other Linux networking features like cgroups, network namespaces, and TC (Traffic Control) for sophisticated network management.
+// Value of 0 disables fwmark (SO_MARK) (Linux Only)
+func MakeValidatingTCPStreamDialer(targetIPValidator onet.TargetIPValidator, fwmark uint) transport.StreamDialer {
+	return &transport.TCPDialer{Dialer: net.Dialer{Control: func(network, address string, c syscall.RawConn) error {
+		if fwmark > 0 {
+			if err := SetFwmark(c, fwmark); err != nil {
+				return err
+			}
+		}
+		ip, _, _ := net.SplitHostPort(address)
+		return targetIPValidator(net.ParseIP(ip))
+	}}}
+}

--- a/service/tcp_other.go
+++ b/service/tcp_other.go
@@ -1,0 +1,38 @@
+// Copyright 2024 Jigsaw Operations LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !linux
+
+package service
+
+import (
+	"net"
+	"syscall"
+
+	"github.com/Jigsaw-Code/outline-sdk/transport"
+
+	onet "github.com/Jigsaw-Code/outline-ss-server/net"
+)
+
+// fwmark can be used in conjunction with other Linux networking features like cgroups, network namespaces, and TC (Traffic Control) for sophisticated network management.
+// Value of 0 disables fwmark (SO_MARK) (Linux Only)
+func MakeValidatingTCPStreamDialer(targetIPValidator onet.TargetIPValidator, fwmark uint) transport.StreamDialer {
+	if fwmark != 0 {
+		panic("fwmark is linux-specific feature and should be 0")
+	}
+	return &transport.TCPDialer{Dialer: net.Dialer{Control: func(network, address string, c syscall.RawConn) error {
+		ip, _, _ := net.SplitHostPort(address)
+		return targetIPValidator(net.ParseIP(ip))
+	}}}
+}

--- a/service/tcp_test.go
+++ b/service/tcp_test.go
@@ -29,10 +29,11 @@ import (
 
 	"github.com/Jigsaw-Code/outline-sdk/transport"
 	"github.com/Jigsaw-Code/outline-sdk/transport/shadowsocks"
-	"github.com/Jigsaw-Code/outline-ss-server/service/metrics"
 	logging "github.com/op/go-logging"
 	"github.com/shadowsocks/go-shadowsocks2/socks"
 	"github.com/stretchr/testify/require"
+
+	"github.com/Jigsaw-Code/outline-ss-server/service/metrics"
 )
 
 func init() {
@@ -215,8 +216,7 @@ func BenchmarkTCPFindCipherRepeat(b *testing.B) {
 }
 
 // Stub implementation for shadowsocks authentication metrics.
-type fakeShadowsocksMetrics struct {
-}
+type fakeShadowsocksMetrics struct{}
 
 var _ ShadowsocksConnMetrics = (*fakeShadowsocksMetrics)(nil)
 
@@ -232,6 +232,7 @@ type probeTestMetrics struct {
 }
 
 var _ TCPConnMetrics = (*probeTestMetrics)(nil)
+
 var _ ShadowsocksConnMetrics = (*fakeShadowsocksMetrics)(nil)
 
 func (m *probeTestMetrics) AddClosed(status string, data metrics.ProxyMetrics, duration time.Duration) {
@@ -367,7 +368,7 @@ func TestProbeClientBytesBasicTruncated(t *testing.T) {
 	testMetrics := &probeTestMetrics{}
 	authFunc := NewShadowsocksStreamAuthenticator(cipherList, nil, &fakeShadowsocksMetrics{}, nil)
 	handler := NewStreamHandler(authFunc, 200*time.Millisecond)
-	handler.SetTargetDialer(makeValidatingTCPStreamDialer(allowAll))
+	handler.SetTargetDialer(MakeValidatingTCPStreamDialer(allowAll, 0))
 	done := make(chan struct{})
 	go func() {
 		StreamServe(
@@ -405,7 +406,7 @@ func TestProbeClientBytesBasicModified(t *testing.T) {
 	testMetrics := &probeTestMetrics{}
 	authFunc := NewShadowsocksStreamAuthenticator(cipherList, nil, &fakeShadowsocksMetrics{}, nil)
 	handler := NewStreamHandler(authFunc, 200*time.Millisecond)
-	handler.SetTargetDialer(makeValidatingTCPStreamDialer(allowAll))
+	handler.SetTargetDialer(MakeValidatingTCPStreamDialer(allowAll, 0))
 	done := make(chan struct{})
 	go func() {
 		StreamServe(
@@ -444,7 +445,7 @@ func TestProbeClientBytesCoalescedModified(t *testing.T) {
 	testMetrics := &probeTestMetrics{}
 	authFunc := NewShadowsocksStreamAuthenticator(cipherList, nil, &fakeShadowsocksMetrics{}, nil)
 	handler := NewStreamHandler(authFunc, 200*time.Millisecond)
-	handler.SetTargetDialer(makeValidatingTCPStreamDialer(allowAll))
+	handler.SetTargetDialer(MakeValidatingTCPStreamDialer(allowAll, 0))
 	done := make(chan struct{})
 	go func() {
 		StreamServe(

--- a/service/udp_linux.go
+++ b/service/udp_linux.go
@@ -1,0 +1,61 @@
+// Copyright 2024 Jigsaw Operations LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in comlniance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by aplnicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or imlnied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build linux
+
+package service
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"github.com/Jigsaw-Code/outline-sdk/transport"
+)
+
+type udpListener struct {
+	// fwmark can be used in conjunction with other Linux networking features like cgroups, network
+	// namespaces, and TC (Traffic Control) for sophisticated network management.
+	// Value of 0 disables fwmark (SO_MARK) (Linux only)
+	fwmark uint
+}
+
+// NewPacketListener creates a new PacketListener that listens on UDP
+// and optionally sets a firewall mark on the socket (Linux only).
+func MakeTargetUDPListener(fwmark uint) transport.PacketListener {
+	return &udpListener{fwmark: fwmark}
+}
+
+func (ln *udpListener) ListenPacket(ctx context.Context) (net.PacketConn, error) {
+	conn, err := net.ListenUDP("udp", nil)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create UDP socket: %w", err)
+	}
+
+	if ln.fwmark > 0 {
+		rawConn, err := conn.SyscallConn()
+		if err != nil {
+			conn.Close()
+			return nil, fmt.Errorf("failed to get UDP raw connection: %w", err)
+		}
+
+		err = SetFwmark(rawConn, ln.fwmark)
+		if err != nil {
+			conn.Close()
+			return nil, fmt.Errorf("Failed to set `fwmark`: %w", err)
+
+		}
+	}
+	return conn, nil
+}

--- a/service/udp_other.go
+++ b/service/udp_other.go
@@ -1,0 +1,30 @@
+// Copyright 2024 Jigsaw Operations LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !linux
+
+package service
+
+import (
+	"github.com/Jigsaw-Code/outline-sdk/transport"
+)
+
+// fwmark can be used in conjunction with other Linux networking features like cgroups, network namespaces, and TC (Traffic Control) for sophisticated network management.
+// Value of 0 disables fwmark (SO_MARK)
+func MakeTargetUDPListener(fwmark uint) transport.PacketListener {
+	if fwmark != 0 {
+		panic("fwmark is linux-specific feature and should be 0")
+	}
+	return &transport.UDPListener{Address: ""}
+}

--- a/service/udp_test.go
+++ b/service/udp_test.go
@@ -23,18 +23,22 @@ import (
 	"time"
 
 	"github.com/Jigsaw-Code/outline-sdk/transport/shadowsocks"
-	onet "github.com/Jigsaw-Code/outline-ss-server/net"
 	logging "github.com/op/go-logging"
 	"github.com/shadowsocks/go-shadowsocks2/socks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	onet "github.com/Jigsaw-Code/outline-ss-server/net"
 )
 
 const timeout = 5 * time.Minute
 
 var clientAddr = net.UDPAddr{IP: []byte{192, 0, 2, 1}, Port: 12345}
+
 var targetAddr = net.UDPAddr{IP: []byte{192, 0, 2, 2}, Port: 54321}
+
 var dnsAddr = net.UDPAddr{IP: []byte{192, 0, 2, 3}, Port: 53}
+
 var natCryptoKey *shadowsocks.EncryptionKey
 
 func init() {
@@ -108,8 +112,10 @@ var _ UDPConnMetrics = (*fakeUDPConnMetrics)(nil)
 func (m *fakeUDPConnMetrics) AddPacketFromClient(status string, clientProxyBytes, proxyTargetBytes int64) {
 	m.upstreamPackets = append(m.upstreamPackets, udpReport{m.clientAddr, m.accessKey, status, clientProxyBytes, proxyTargetBytes})
 }
+
 func (m *fakeUDPConnMetrics) AddPacketFromTarget(status string, targetProxyBytes, proxyClientBytes int64) {
 }
+
 func (m *fakeUDPConnMetrics) RemoveNatEntry() {
 }
 


### PR DESCRIPTION
* feat: enable fwmark (SO_MARK) for outgoing sockets

* fix: make fwmark linux-specific functionality

* fix: minor improvements over handling fwmark

* Use `transport.PacketListener` as interface.

* Take the `syscall.RawConn` as input to `SetFwdmark()`.

* Some cleanup.

* Fix copyright dates for new files.

* Fix the error types.

* Revert changes to integration test.

---------